### PR TITLE
Set 1 as the default seed of rand

### DIFF
--- a/lib/Algorithm/LibSVM.pm6
+++ b/lib/Algorithm/LibSVM.pm6
@@ -16,12 +16,14 @@ my sub svm_check_probability_model(Algorithm::LibSVM::Model) returns int32 is na
 
 my sub print_string_stdout(Str) returns Pointer[void] is native($library) { * }
 my sub svm_set_print_string_function(&print_func (Str --> Pointer[void])) is native($library) { * }
+my sub svm_set_srand(int32) is native($library) { * }
 
-submethod BUILD(Bool :$verbose? = False) {
+submethod BUILD(Bool :$verbose? = False, Int :$seed = 1) {
     unless $verbose {
         my $f = sub (Str --> Pointer[void]) { Nil };
         svm_set_print_string_function($f);
     }
+    svm_set_srand($seed);
 }
 
 method cross-validation(Algorithm::LibSVM::Problem $problem, Algorithm::LibSVM::Parameter $param, Int $nr-fold) returns Array {

--- a/src/3.22/svm.cpp.patch
+++ b/src/3.22/svm.cpp.patch
@@ -35,7 +35,7 @@
 //  Copyright(C) 2017 titsuki <titsuki@cpan.org>
 // For more details, see the "LICENSE" file.
 --- libsvm-3.22/svm.cpp	2016-12-22 02:58:58.000000000 +0900
-+++ libsvm-3.22-new/svm.cpp	2017-01-08 22:42:44.664729818 +0900
++++ libsvm-3.22-new/svm.cpp	2017-01-09 20:01:56.486976818 +0900
 @@ -246,7 +246,10 @@
  	}
  	double kernel_precomputed(int i, int j) const
@@ -140,3 +140,12 @@
  			++j;
  		}
  		x_space[j++].index = -1;
+@@ -3179,3 +3186,8 @@
+ 	else
+ 		svm_print_string = print_func;
+ }
++
++void svm_set_srand(int seed)
++{
++	srand(seed);
++}

--- a/src/3.22/svm.h.patch
+++ b/src/3.22/svm.h.patch
@@ -35,7 +35,7 @@
 //  Copyright(C) 2017 titsuki <titsuki@cpan.org>
 // For more details, see the "LICENSE" file.
 --- libsvm-3.22/svm.h	2016-12-22 02:58:58.000000000 +0900
-+++ libsvm-3.22-new/svm.h	2017-01-02 16:26:55.623160330 +0900
++++ libsvm-3.22-new/svm.h	2017-01-09 19:57:43.582976818 +0900
 @@ -13,6 +13,7 @@
  {
  	int index;
@@ -44,3 +44,11 @@
  };
  
  struct svm_problem
+@@ -96,6 +97,7 @@
+ int svm_check_probability_model(const struct svm_model *model);
+ 
+ void svm_set_print_string_function(void (*print_func)(const char *));
++void svm_set_srand(int seed);
+ 
+ #ifdef __cplusplus
+ }


### PR DESCRIPTION
Fix #9 
I  confirmed this issue was solved by testing manually (i.e. Under the same seed, both this bindings and the original script generate a same model).