### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -10,6 +10,7 @@
   ],
   "description" : "A Perl 6 bindings for libsvm",
   "name" : "Algorithm::LibSVM",
+  "license" : "MIT",
   "perl" : "6.c",
   "provides" : {
     "Algorithm::LibSVM" : "lib/Algorithm/LibSVM.pm6",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license